### PR TITLE
update apply_relocate_add for R_X86_64_PC64 and R_X86_64_PLT32

### DIFF
--- a/shim/bios_shim.c
+++ b/shim/bios_shim.c
@@ -344,8 +344,13 @@ static int _apply_relocate_add(Elf64_Shdr *sechdrs, const char *strtab, unsigned
                 goto overflow;
                 break;
             case R_X86_64_PC32:
+            case R_X86_64_PLT32:
                 val -= (u64)loc;
                 *(u32 *)loc = val;
+                break;
+            case R_X86_64_PC64:
+                val -= (u64)loc;
+                *(u64 *)loc = val;
                 break;
             default:
                 pr_err("%s: Unknown rela relocation: %llu\n",


### PR DESCRIPTION
For SA6400 DSM 7.2, there are many errors when load modules: 
`Unknown rela relocation: 4`

The root cause is that the `apply_relocate_add` is outdated, so update it here.